### PR TITLE
fix: #18 Go バージョンを 1.25.6 から 1.26 に更新

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ousiassllc/linterly
 
-go 1.25.6
+go 1.26
 
 require (
 	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817


### PR DESCRIPTION
Closes #18

## Summary
- `go.mod` の `go` ディレクティブを `1.25.6` から `1.26` に更新
- `go mod tidy` で `go.sum` の同期を確認（差分なし）

## 手動チェック項目

### 動作確認
- [ ] `make build` でバイナリが正常にビルドできる
- [ ] `linterly --version` が正常に動作する

### 品質
- [ ] lint / format がパスする
- [ ] テストがすべてパスする