### PR TITLE
fix: GoReleaser の changelog 設定を --release-notes と競合しない方式に変更

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,4 +33,7 @@ checksum:
   algorithm: sha256
 
 changelog:
-  disable: true
+  sort: asc
+  filters:
+    exclude:
+      - ".*"


### PR DESCRIPTION
Closes #41

## Summary

- `.goreleaser.yml` の `changelog: disable: true` を `filters.exclude: [".*"]` に変更
- `disable: true` は GoReleaser の自動生成 changelog だけでなく `--release-notes` フラグも無効化していた
- フィルタベースの除外にすることで、自動生成 changelog を実質無効にしつつ `--release-notes` が正常に動作するようになる

## 手動チェック項目

### 品質
- [x] lint / format がパスする
- [x] テストがすべてパスする

### デプロイ
- [ ] 次回リリース時に GitHub Release のリリースノートが正しく反映されることを確認